### PR TITLE
Prepend "http://" if it's missing from the Heroku app URL config var

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,23 @@ module.exports = {
   }
 };
 ```
+## Running the bot
+
+### Heroku
+
+I used:
+
+```bash
+heroku buildpacks:set https://github.com/heroku/heroku-buildpack-nodejs#v89 -a
+```
+and
+
+```bash
+git push heroku master
+```
+
+### Locally
+
+```bash
+node agolo-slackbot.js
+```

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -60,6 +60,8 @@ var summarize = function(url, callback, typingInterval) {
 		if (data && data.summary && data.summary.sentences) {
 			var sentences = data.summary[0].sentences;
 
+			console.log("sentences: \n", sentences);
+
 			// Quote each line
 			for (var i = 0; i < sentences.length; i++) {
 				sentences[i] = ">" + sentences[i];

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -14,7 +14,8 @@ if (process.env.SLACK_TOKEN && process.env.AGOLO_URL) {
 	TOKEN = process.env.SLACK_TOKEN;
 	AGOLO_URL = process.env.AGOLO_URL;
 	HEROKU = true;
-	console.log("Slack token: " + process.env.SLACK_TOKEN);
+	
+	console.log("Slack token: " + TOKEN);
 } else {
 	// For local
 	var SlackSecret = require('./slack-secrets.js');
@@ -127,10 +128,16 @@ if (HEROKU) {
 	server.listen(process.env.PORT || 5000);
 
 	if (process.env.HEROKU_APP_URL) {
-		console.log("Heroku app URL: " + process.env.HEROKU_APP_URL);
-		
+		var URL = process.env.HEROKU_APP_URL;
+
+		if (URL.indexOf("http") != 0) {
+			URL = "http://" + URL;
+		}
+
+		console.log("Heroku app URL: " + URL);
+
 		var heartbeat = function() {
-			restClient.get(process.env.HEROKU_APP_URL, function(){
+			restClient.get(URL, function(){
 				console.log("heartbeat!");
 			});
 		};

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -127,6 +127,8 @@ if (HEROKU) {
 	server.listen(process.env.PORT || 5000);
 
 	if (process.env.HEROKU_APP_URL) {
+		console.log("Heroku app URL: " + process.env.HEROKU_APP_URL);
+		
 		var heartbeat = function() {
 			restClient.get(process.env.HEROKU_APP_URL, function(){
 				console.log("heartbeat!");

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -31,7 +31,7 @@ var restClient = new RestClient();
 var bot; // Track bot user .. for detecting messages by yourself
 
 // Summarize a given URL and call the given callback with the result
-var summarize = function(url, callback, typingInterval) {
+var summarize = function(url, typingInterval, callback) {
 	var result = "Here's Agolo's summary of " + url + "\n";
 
 	var args = {
@@ -111,8 +111,8 @@ slackClient.on("message", function(message) {
     				var typingInterval = setInterval(function() { sendTypingMessage() }, TYPING_MESSAGE_SECS * 1000);
     				
 
-    				summarize(candidate, function(result) {
-    					slackClient.sendMessage(result, channel, typingInterval);
+    				summarize(candidate, typingInterval, function(result) {
+    					slackClient.sendMessage(result, channel);
     				});
     			}
     		}

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -57,7 +57,7 @@ var summarize = function(url, typingInterval, callback) {
 
 		clearInterval(typingInterval);
 
-		if (data && data.summary && data.summary.sentences) {
+		if (data && data.summary && data.summary[0].sentences) {
 			var sentences = data.summary[0].sentences;
 
 			console.log("sentences: \n", sentences);

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -31,7 +31,7 @@ var restClient = new RestClient();
 var bot; // Track bot user .. for detecting messages by yourself
 
 // Summarize a given URL and call the given callback with the result
-var summarize = function(url, callback) {
+var summarize = function(url, callback, typingInterval) {
 	var result = "Here's Agolo's summary of " + url + "\n";
 
 	var args = {

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -14,6 +14,7 @@ if (process.env.SLACK_TOKEN && process.env.AGOLO_URL) {
 	TOKEN = process.env.SLACK_TOKEN;
 	AGOLO_URL = process.env.AGOLO_URL;
 	HEROKU = true;
+	console.log("Slack token: " + process.env.SLACK_TOKEN);
 } else {
 	// For local
 	var SlackSecret = require('./slack-secrets.js');

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -54,16 +54,21 @@ var summarize = function(url, callback) {
 	restClient.post(AGOLO_URL, args, function (data, rawResponse) {
 		console.log("Agolo response: ");
 		console.log(data);
-		var sentences = data.summary[0].sentences;
 
-		// Quote each line
-		for (var i = 0; i < sentences.length; i++) {
-			sentences[i] = ">" + sentences[i];
+		clearInterval(typingInterval);
+
+		if (data && data.summary && data.summary.sentences) {
+			var sentences = data.summary[0].sentences;
+
+			// Quote each line
+			for (var i = 0; i < sentences.length; i++) {
+				sentences[i] = ">" + sentences[i];
+			}
+
+			result = result + sentences.join("\n-\n");
+
+			callback(result);
 		}
-
-		result = result + sentences.join("\n-\n");
-
-		callback(result);
 	});
 }
 
@@ -105,8 +110,7 @@ slackClient.on("message", function(message) {
     				
 
     				summarize(candidate, function(result) {
-    					clearInterval(typingInterval);
-    					slackClient.sendMessage(result, channel);
+    					slackClient.sendMessage(result, channel, typingInterval);
     				});
     			}
     		}

--- a/agolo-slackbot.js
+++ b/agolo-slackbot.js
@@ -57,19 +57,23 @@ var summarize = function(url, typingInterval, callback) {
 
 		clearInterval(typingInterval);
 
-		if (data && data.summary && data.summary[0].sentences) {
-			var sentences = data.summary[0].sentences;
+		if (data && data.summary) {
+			for (var summIdx = 0; summIdx < data.summary.length; summIdx++) {
+				if (data.summary[summIdx].sentences) {
+					var sentences = data.summary[summIdx].sentences;
 
-			console.log("sentences: \n", sentences);
+					console.log("sentences for summary " + summIdx + ": \n", sentences);
 
-			// Quote each line
-			for (var i = 0; i < sentences.length; i++) {
-				sentences[i] = ">" + sentences[i];
+					// Quote each line
+					for (var i = 0; i < sentences.length; i++) {
+						sentences[i] = ">" + sentences[i];
+					}
+
+					result = result + sentences.join("\n-\n");
+
+					callback(result);
+				}
 			}
-
-			result = result + sentences.join("\n-\n");
-
-			callback(result);
 		}
 	});
 }


### PR DESCRIPTION
When you copy the URL from the Heroku web UI, it doesn't have an "http://" in front of it. The script should accommodate that.
